### PR TITLE
Made the filter menu responsive

### DIFF
--- a/src/Pages/Home/Home.css
+++ b/src/Pages/Home/Home.css
@@ -25,7 +25,6 @@
 .filter{
     position: absolute;
     top: 5px;
-    left: 5px;
     background-color: rgb(27, 27, 27);
     color: #fff;
 }
@@ -39,12 +38,21 @@
     color: #fff;
 }
 
+.navbar-close-btn{
+    font-size: 2rem;
+    cursor: pointer;
+    display: block;
+}
+
 @media screen and (min-width:768px){
     .sidebar{
         display: block;
     }
     .filter{
         display: none;
+    }
+    .navbar-close-btn{
+    display: none;
     }
 
 }

--- a/src/Pages/Home/Home.js
+++ b/src/Pages/Home/Home.js
@@ -28,9 +28,10 @@ const Home = () => {
 		return (
 			<div className="home-container">
 				<div className={filter ? "sidebar open" : "sidebar"}>
+					<div className='navbar-close-btn' onClick={()=>setFilter(!filter)}>&times;</div>
 					<SectionListing selectedSection={selectedSection} setSelectedSection={setSelectedSection} setFilter={setFilter}/>
 				</div>
-				<button className={filter ? "filter filter-close" : "filter"} onClick={()=>setFilter(!filter)}>
+				{!filter && <button className={filter ? "filter filter-close" : "filter"} onClick={()=>setFilter(!filter)}>
 					{
 						filter ? 
 							"Close"
@@ -39,7 +40,7 @@ const Home = () => {
 					}
 
 
-				</button>
+				</button>}
 				<NewsArticle selectedSection={selectedSection} setSelectedSection={setSelectedSection} user={user}/>
 			</div>
 		);


### PR DESCRIPTION
Made the filter menu completely responsive for mobile devices. Now there is no extra space and content doesn't flow out of the viewport.
This PR is related to the [issue](https://github.com/vishnuvnathan/nyt-news-app/issues/7)